### PR TITLE
fix(actions): use podman load instead of import

### DIFF
--- a/.github/actions/oci-build/action.yml
+++ b/.github/actions/oci-build/action.yml
@@ -26,10 +26,6 @@ inputs:
     required: false
     description: 'The containerfile to use to build the image'
     default: './Containerfile'
-  image-name:
-    required: false
-    description: 'The name of the image'
-    default: ${{ github.repository }}
 
 outputs:
   artifact-id:
@@ -49,12 +45,12 @@ runs:
     - name: Build Image
       uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 #v2.13
       with:
-        image: ${{ inputs.image-name }}
+        image: localhost/image
         containerfiles: ${{ inputs.containerfile }}
         context: .
         extra-args: |
           --squash
-          --output type=tar,dest=oci-image.tar
+          --tag oci-archive:oci-image.tar
 
     - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       id: upload-oci-image

--- a/.github/actions/oci-publish/action.yml
+++ b/.github/actions/oci-publish/action.yml
@@ -54,10 +54,9 @@ inputs:
     description: 'The name of the image to publish'
     default: ${{ github.repository }}
 
-  tag:
+  tags:
     required: true
-    description: 'The tag to publish the image with'
-
+    description: 'Whitespace-separated list of tags'
 
 runs:
   using: "composite"
@@ -85,9 +84,32 @@ runs:
         password: ${{ inputs.registry-password }}
         registry: ${{ inputs.registry }}
 
-    - name: Import image
+    - name: Load image
+      id: load-image
       shell: bash
-      run: podman import oci-image.tar ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+        
+        OUTPUT=$(podman load -i oci-image.tar)
+        echo "$OUTPUT"
+        
+        IMAGE=$(echo "$OUTPUT" | awk -F': ' '/Loaded image:/ {print $2}' | tail -n1)
+        
+        if [ -z "$IMAGE" ]; then
+          echo "❌ Failed to determine loaded image name"
+          exit 1
+        fi
+        
+        echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+    - name: Tag image(s)
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        for TAG in ${{ inputs.tags }}; do
+          podman tag "${{ steps.load-image.outputs.image }}" "${{ inputs.image-name }}:$TAG"
+        done
 
     - name: Push Image
       id: push-to-registry
@@ -95,7 +117,7 @@ runs:
       with:
         registry: ${{ inputs.registry }}
         image: ${{ inputs.image-name }}
-        tags: ${{ inputs.tag }}
+        tags: ${{ inputs.tags }}
 
     - name: Generate artifact attestation
       uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 #v4.1.0


### PR DESCRIPTION
## Description

As raised in https://github.com/podman-desktop/gh-extensions-actions/issues/9 the actions are currently unusable because they are exporting the image as a tarball (filesystem) without any manifest, meaning we lose all the LABEL(s), which is a big problem, as Podman Desktop requires a series of label to validate the image.

This PR change the options of `redhat-actions/buildah-build` to export as `oci-archive` instead of `tar`, this allow us to use `podman load` instead of `podman import`.

## Related issues

Fixes https://github.com/podman-desktop/gh-extensions-actions/issues/9