### PR TITLE
feat(workflows): add static pr-check workflow 

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: pr-check
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  static-checks:
+    name: static-checks
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The only linter here that reads composite actions as well as workflows.
+      # advanced-security: false makes it fail the job on findings instead of
+      # uploading SARIF (and is required for annotations to work at all).
+      - name: zizmor
+        if: ${{ !cancelled() }}
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
+        with:
+          advanced-security: false
+          annotations: true
+
+      # actionlint publishes no marketplace action, but its official image works
+      # as one. The image bundles shellcheck, so the run: blocks of this file and
+      # of publish-oci-pr.yml get linted too. It cannot inspect composite action
+      # metadata (rhysd/actionlint#401) - zizmor covers .github/actions/* instead.
+      - name: actionlint
+        if: ${{ !cancelled() }}
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # 1.7.12
+        with:
+          args: -color


### PR DESCRIPTION
## Description

We have a few workflow and shared GitHub actions in this repository, but we don't really have anything that ensure that we don't merge stuff that are breaking.

We (Claude & I) found two projects 

- [zizmor](https://github.com/zizmorcore/zizmor): Static analysis for GitHub Actions
- [actionlint](https://github.com/rhysd/actionlint): Static checker for GitHub Actions workflow files

actionlint cannot inspect composite action metadata (rhysd/actionlint#401), so zizmor is what covers .github/actions/*.
