### PR TITLE
feat(workflows): auto minor release on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'release'
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Cut the next minor release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          fetch-depth: 0 # required: tags are needed to derive the next version
+
+      - name: Resolve next minor version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          latest=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
+          if [[ -z "$latest" ]]; then
+            echo "::error::No vX.Y.Z tag found: cannot derive the next version. Create the first tag by hand."
+            exit 1
+          fi
+          IFS='.' read -r major minor _patch <<< "${latest#v}"
+          next="v${major}.$((minor + 1)).0"
+          echo "Latest tag: $latest -> next: $next"
+          echo "next=$next" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          NEXT: ${{ steps.version.outputs.next }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "$NEXT" \
+            --target "$GITHUB_SHA" \
+            --title "$NEXT" \
+            --generate-notes


### PR DESCRIPTION
## Description

With https://github.com/podman-desktop/gh-extensions-actions/pull/16 we configured dependabot, and some extensions are starting to use the shared GitHub actions, however in those extensions, to be updated, we need to make a release, and doing this by hand is tedious.

Instead we can auto-release minor when pushing on main.

## Testing

You can check the core logic are split in two command

1. Get the latest version 

```bash
$ latest=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
$ echo $latest
v0.2.0 
```

2.  Extract major / minor / patch

:information_source: IFS is the delimiter, we split `v0.2.0` by the point

```bash
$ IFS='.' read -r major minor _patch <<< "${latest#v}"
$ echo $major $minor $_patch
0 2 0
```